### PR TITLE
Use --database option to determine which database to use in migrate command

### DIFF
--- a/django_north/management/commands/flush.py
+++ b/django_north/management/commands/flush.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
 
         # custom: only_django False
         # get current version before flush
-        current_version = get_current_version()
+        current_version = get_current_version(connection)
         sql_list = sql_flush(self.style, connection, only_django=False,
                              reset_sequences=reset_sequences,
                              allow_cascade=allow_cascade)

--- a/django_north/management/commands/runserver.py
+++ b/django_north/management/commands/runserver.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.contrib.staticfiles.management.commands.runserver import \
     Command as RunserverCommand
+from django.db import connection
 
 from django_north.management import migrations
 
@@ -11,7 +12,7 @@ class Command(RunserverCommand):
 
     def check_migrations(self):
         try:
-            migration_plan = migrations.build_migration_plan()
+            migration_plan = migrations.build_migration_plan(connection)
         except migrations.DBException as e:
             self.stdout.write(self.style.NOTICE("\n{}\n".format(e)))
             return

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-coverage==4.1
+coverage==4.4
 psycopg2>=2.6.2
 dj_database_url>=0.4.1
 django_extensions

--- a/tests/north_project/settings.py
+++ b/tests/north_project/settings.py
@@ -18,7 +18,10 @@ if "DATABASE_URL" not in os.environ or \
 
 DEBUG = True
 USE_TZ = True
-DATABASES = {"default": dj_database_url.config()}
+DATABASES = {
+    "default": dj_database_url.config(),
+    "foo": dj_database_url.config(),
+}
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/tests/test_management_migrations.py
+++ b/tests/test_management_migrations.py
@@ -35,7 +35,7 @@ def test_get_applied_versions(mocker):
 
     recorder = migrations.MigrationRecorder(connection)
     recorder.record_applied('1.10', 'fake-ddl.sql')
-    result = migrations.get_applied_versions()
+    result = migrations.get_applied_versions(connection)
     assert result == ['1.0', '1.1', '1.2', '1.3', '1.10']
 
 
@@ -173,12 +173,12 @@ def test_build_migration_plan(settings, mocker):
 
     # current version is None
     mock_get_current_version.return_value = None
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result is None
 
     # current version is not None
     mock_get_current_version.return_value = '16.12'
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result['current_version'] == '16.12'
     assert result['init_version'] == '16.12'
     assert len(result['plans']) == 2
@@ -189,11 +189,11 @@ def test_build_migration_plan(settings, mocker):
     mock_get_current_version.return_value = 'foo'
     message = "The current version of the database is unknown: foo."
     with pytest.raises(migrations.DBException, message=message):
-        migrations.build_migration_plan()
+        migrations.build_migration_plan(connection)
 
     # current version is the last one
     mock_get_current_version.return_value = '17.02'
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result['current_version'] == '17.02'
     assert result['init_version'] == '17.02'
     assert len(result['plans']) == 0
@@ -206,7 +206,7 @@ def test_build_migration_plan(settings, mocker):
         "settings.NORTH_TARGET_VERSION is improperly configured: "
         "version foo not found.")
     with pytest.raises(ImproperlyConfigured, message=message):
-        migrations.build_migration_plan()
+        migrations.build_migration_plan(connection)
 
     settings.NORTH_TARGET_VERSION = '17.02'
 
@@ -218,7 +218,7 @@ def test_build_migration_plan(settings, mocker):
         [],
         [],
     ]
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result['current_version'] == '16.12'
     assert result['init_version'] == '16.11'
     assert len(result['plans']) == 3
@@ -234,7 +234,7 @@ def test_build_migration_plan(settings, mocker):
     mock_get_applied_migrations.side_effect = [
         [],
     ]
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result['current_version'] == '17.02'
     assert result['init_version'] == '17.01'
     assert len(result['plans']) == 1
@@ -247,7 +247,7 @@ def test_build_migration_plan(settings, mocker):
         [],
         [],
     ]
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result['current_version'] == '17.02'
     assert result['init_version'] == '16.12'
     assert len(result['plans']) == 2
@@ -265,7 +265,7 @@ def test_build_migration_plan(settings, mocker):
         ['16.12-0-version-dml.sql'],
         [],
     ]
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result['current_version'] == '16.12'
     assert result['init_version'] == '16.11'
     assert len(result['plans']) == 2
@@ -282,7 +282,7 @@ def test_build_migration_plan(settings, mocker):
         [],
         [],
     ]
-    result = migrations.build_migration_plan()
+    result = migrations.build_migration_plan(connection)
     assert result['current_version'] == '17.02'
     assert result['init_version'] == '16.11'
     assert len(result['plans']) == 2


### PR DESCRIPTION
In order to run migrations on another database than `'default'`.