### PR TITLE
NORTH_AFTER_SCHEMA_FILES

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ History
 
 - Add support for Django 2.1 & Python 3.7
 - Add setting `NORTH_AFTER_SCHEMA_FILES` for schema files after the main schema.
+- Adding setting `NORTH_BEFORE_SCHEMA_FILES`, to replace `NORTH_ADDITIONAL_SCHEMA_FILES`.
+- Deprecate setting `NORTH_ADDITIONAL_SCHEMA_FILES`.
 
 0.2.4 (2018-09-12)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 ++++++++++++++++++
 
 - Add support for Django 2.1 & Python 3.7
+- Add setting `NORTH_AFTER_SCHEMA_FILES` for schema files after the main schema.
 
 0.2.4 (2018-09-12)
 ++++++++++++++++++

--- a/django_north/management/commands/migrate.py
+++ b/django_north/management/commands/migrate.py
@@ -73,6 +73,16 @@ class Command(BaseCommand):
                     self.run_script(path)
                     recorder.record_applied(version, mig)
 
+    def _load_schema_file(self, file_name, load_name=None):
+        file_path = os.path.join(
+            settings.NORTH_MIGRATIONS_ROOT, 'schemas', file_name)
+        if self.verbosity >= 1:
+            if load_name is None:
+                load_name = file_name
+            self.stdout.write(
+                self.style.MIGRATE_LABEL("Load {}".format(load_name)))
+        self.run_script(file_path)
+
     def init_schema(self):
         init_version = migrations.get_version_for_init()
 
@@ -80,35 +90,22 @@ class Command(BaseCommand):
         additional_files = getattr(
             settings, 'NORTH_ADDITIONAL_SCHEMA_FILES', [])
         for file_name in additional_files:
-            file_path = os.path.join(
-                settings.NORTH_MIGRATIONS_ROOT, 'schemas', file_name)
-            if self.verbosity >= 1:
-                self.stdout.write(
-                    self.style.MIGRATE_LABEL("Load {}".format(file_name)))
-            self.run_script(file_path)
+            self._load_schema_file(file_name)
 
         # load schema
+        schema_file = getattr(
+            settings, 'NORTH_SCHEMA_TPL',
+            migrations.schema_default_tpl
+        ).format(init_version)
+        self._load_schema_file(schema_file, load_name="schema")
         if self.verbosity >= 1:
-            self.stdout.write(self.style.MIGRATE_LABEL("Load schema"))
             self.stdout.write("  Applying {}...".format(init_version))
-        schema_path = os.path.join(
-            settings.NORTH_MIGRATIONS_ROOT,
-            'schemas',
-            getattr(settings, 'NORTH_SCHEMA_TPL',
-                    migrations.schema_default_tpl)
-            .format(init_version))
-        self.run_script(schema_path)
 
         # load other set of additional files
         after_files = getattr(
             settings, 'NORTH_AFTER_SCHEMA_FILES', [])
         for file_name in after_files:
-            file_path = os.path.join(
-                settings.NORTH_MIGRATIONS_ROOT, 'schemas', file_name)
-            if self.verbosity >= 1:
-                self.stdout.write(
-                    self.style.MIGRATE_LABEL("Load {}".format(file_name)))
-            self.run_script(file_path)
+            self._load_schema_file(file_name)
 
         # load fixtures
         try:

--- a/django_north/management/commands/migrate.py
+++ b/django_north/management/commands/migrate.py
@@ -2,6 +2,7 @@
 import io
 import logging
 import os.path
+import warnings
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -86,9 +87,18 @@ class Command(BaseCommand):
     def init_schema(self):
         init_version = migrations.get_version_for_init()
 
-        # load additional files
+        # load first set of additional files
+        after_files = getattr(
+            settings, 'NORTH_BEFORE_SCHEMA_FILES', [])
+        for file_name in after_files:
+            self._load_schema_file(file_name)
+
+        # load additional files (deprecated)
         additional_files = getattr(
             settings, 'NORTH_ADDITIONAL_SCHEMA_FILES', [])
+        if additional_files:
+            warnings.warn("NORTH_ADDITIONAL_SCHEMA_FILES will be deprecated. "
+                          "Use NORTH_BEFORE_SCHEMA_FILES instead.")
         for file_name in additional_files:
             self._load_schema_file(file_name)
 

--- a/django_north/management/commands/migrate.py
+++ b/django_north/management/commands/migrate.py
@@ -99,6 +99,17 @@ class Command(BaseCommand):
             .format(init_version))
         self.run_script(schema_path)
 
+        # load other set of additional files
+        after_files = getattr(
+            settings, 'NORTH_AFTER_SCHEMA_FILES', [])
+        for file_name in after_files:
+            file_path = os.path.join(
+                settings.NORTH_MIGRATIONS_ROOT, 'schemas', file_name)
+            if self.verbosity >= 1:
+                self.stdout.write(
+                    self.style.MIGRATE_LABEL("Load {}".format(file_name)))
+            self.run_script(file_path)
+
         # load fixtures
         try:
             fixtures_version = migrations.get_fixtures_for_init(init_version)

--- a/django_north/management/commands/migrate.py
+++ b/django_north/management/commands/migrate.py
@@ -88,9 +88,9 @@ class Command(BaseCommand):
         init_version = migrations.get_version_for_init()
 
         # load first set of additional files
-        after_files = getattr(
+        before_files = getattr(
             settings, 'NORTH_BEFORE_SCHEMA_FILES', [])
-        for file_name in after_files:
+        for file_name in before_files:
             self._load_schema_file(file_name)
 
         # load additional files (deprecated)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,7 +29,10 @@ List of available settings:
   To be used if you need to force the version used to init a new DB.
 * ``NORTH_SCHEMA_TPL``: default value ``schema_{}.sql``
 * ``NORTH_FIXTURES_TPL``: default value ``fixtures_{}.sql``
-* ``NORTH_ADDITIONAL_SCHEMA_FILES``: list of sql files to load before the schema.
+* ``NORTH_ADDITIONAL_SCHEMA_FILES``: **deprecated** list of sql files to load before the schema.
+  For example: a file of DB roles, some extensions.
+  Default value: ``[]``
+* ``NORTH_BEFORE_SCHEMA_FILES``: list of sql files to load before the schema.
   For example: a file of DB roles, some extensions.
   Default value: ``[]``
 * ``NORTH_AFTER_SCHEMA_FILES``: list of sql files to load after the schema.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -32,6 +32,9 @@ List of available settings:
 * ``NORTH_ADDITIONAL_SCHEMA_FILES``: list of sql files to load before the schema.
   For example: a file of DB roles, some extensions.
   Default value: ``[]``
+* ``NORTH_AFTER_SCHEMA_FILES``: list of sql files to load after the schema.
+  For example: a file of permissions, grants on tables
+  Default value: ``[]``
 * ``NORTH_CURRENT_VERSION_DETECTOR``: the current version detector.
   Default value: ``django_north.management.migrations.get_current_version_from_table``
 * ``NORTH_NON_TRANSACTIONAL_KEYWORDS``: list of keywords.

--- a/tests/test_migrate_command.py
+++ b/tests/test_migrate_command.py
@@ -1,4 +1,5 @@
 import os.path
+import warnings
 
 from django.core.management import call_command
 from django.db import connection
@@ -42,7 +43,7 @@ def test_migrate_run_script(settings, mocker):
     assert len(mock_run.call_args_list) == 1
 
 
-def test_migrate_init_schema(capsys, settings, mocker):
+def test_migrate_init_schema_fixture(capsys, settings, mocker):
     root = os.path.dirname(__file__)
     settings.NORTH_MIGRATIONS_ROOT = os.path.join(root, 'test_data/sql')
 
@@ -58,6 +59,10 @@ def test_migrate_init_schema(capsys, settings, mocker):
     # no additional files
     if hasattr(settings, 'NORTH_ADDITIONAL_SCHEMA_FILES'):
         del settings.NORTH_ADDITIONAL_SCHEMA_FILES
+    if hasattr(settings, 'NORTH_BEFORE_SCHEMA_FILES'):
+        del settings.NORTH_BEFORE_SCHEMA_FILES
+    if hasattr(settings, 'NORTH_AFTER_SCHEMA_FILES'):
+        del settings.NORTH_AFTER_SCHEMA_FILES
     command.init_schema()
     assert len(mock_run_script.call_args_list) == 2
     assert mock_run_script.call_args_list[0] == mocker.call(
@@ -74,12 +79,23 @@ def test_migrate_init_schema(capsys, settings, mocker):
         '  Applying 16.12...\n'
     )
 
-    mock_run_script.reset_mock()
+
+def test_migrate_init_extension_schema_fixture(capsys, settings, mocker):
+    root = os.path.dirname(__file__)
+    settings.NORTH_MIGRATIONS_ROOT = os.path.join(root, 'test_data/sql')
+
+    mocker.patch(
+        'django_north.management.migrations.get_version_for_init',
+        return_value='16.12')
+    mock_run_script = mocker.patch(
+        'django_north.management.commands.migrate.Command.run_script')
     command = migrate.Command()
     command.verbosity = 2
 
     # extensions & fixtures
-    settings.NORTH_ADDITIONAL_SCHEMA_FILES = ['extension.sql']
+    settings.NORTH_BEFORE_SCHEMA_FILES = ['extension.sql']
+    settings.NORTH_ADDITIONAL_SCHEMA_FILES = []
+    settings.NORTH_AFTER_SCHEMA_FILES = []
     command.init_schema()
     assert len(mock_run_script.call_args_list) == 3
     assert mock_run_script.call_args_list[0] == mocker.call(
@@ -100,12 +116,23 @@ def test_migrate_init_schema(capsys, settings, mocker):
         '  Applying 16.12...\n'
     )
 
-    mock_run_script.reset_mock()
+
+def test_migrate_init_extension_roles_schema_fixture(capsys, settings, mocker):
+    root = os.path.dirname(__file__)
+    settings.NORTH_MIGRATIONS_ROOT = os.path.join(root, 'test_data/sql')
+
+    mocker.patch(
+        'django_north.management.migrations.get_version_for_init',
+        return_value='16.12')
+    mock_run_script = mocker.patch(
+        'django_north.management.commands.migrate.Command.run_script')
     command = migrate.Command()
     command.verbosity = 2
 
     # extensions, roles & fixtures
-    settings.NORTH_ADDITIONAL_SCHEMA_FILES = ['extension.sql', 'roles.sql']
+    settings.NORTH_BEFORE_SCHEMA_FILES = ['extension.sql', 'roles.sql']
+    settings.NORTH_AFTER_SCHEMA_FILES = []
+    settings.NORTH_ADDITIONAL_SCHEMA_FILES = []
     command.init_schema()
     assert len(mock_run_script.call_args_list) == 4
     assert mock_run_script.call_args_list[0] == mocker.call(
@@ -130,13 +157,23 @@ def test_migrate_init_schema(capsys, settings, mocker):
         '  Applying 16.12...\n'
     )
 
-    mock_run_script.reset_mock()
+
+def test_migrate_init_full(capsys, settings, mocker):
+    root = os.path.dirname(__file__)
+    settings.NORTH_MIGRATIONS_ROOT = os.path.join(root, 'test_data/sql')
+
+    mocker.patch(
+        'django_north.management.migrations.get_version_for_init',
+        return_value='16.12')
+    mock_run_script = mocker.patch(
+        'django_north.management.commands.migrate.Command.run_script')
     command = migrate.Command()
     command.verbosity = 2
 
     # extensions, roles, fixtures, and grants
-    settings.NORTH_ADDITIONAL_SCHEMA_FILES = ['extension.sql', 'roles.sql']
+    settings.NORTH_BEFORE_SCHEMA_FILES = ['extension.sql', 'roles.sql']
     settings.NORTH_AFTER_SCHEMA_FILES = ['grants.sql']
+    settings.NORTH_ADDITIONAL_SCHEMA_FILES = []
     command.init_schema()
     assert len(mock_run_script.call_args_list) == 5
     assert mock_run_script.call_args_list[0] == mocker.call(
@@ -165,16 +202,68 @@ def test_migrate_init_schema(capsys, settings, mocker):
         '  Applying 16.12...\n'
     )
 
-    mock_run_script.reset_mock()
+
+def test_migrate_init_deprecation(capsys, settings, mocker):
+    root = os.path.dirname(__file__)
+    settings.NORTH_MIGRATIONS_ROOT = os.path.join(root, 'test_data/sql')
+
+    mocker.patch(
+        'django_north.management.migrations.get_version_for_init',
+        return_value='16.12')
+    mock_run_script = mocker.patch(
+        'django_north.management.commands.migrate.Command.run_script')
     command = migrate.Command()
     command.verbosity = 2
+
+    # deprecating warning
+    settings.NORTH_ADDITIONAL_SCHEMA_FILES = ['extension.sql', 'roles.sql']
+    settings.NORTH_BEFORE_SCHEMA_FILES = []
+    settings.NORTH_AFTER_SCHEMA_FILES = []
+    with warnings.catch_warnings(record=True) as warns:
+        command.init_schema()
+        assert len(warns) == 1
+        assert "NORTH_BEFORE_SCHEMA_FILES" in str(warns[0].message)
+
+    assert len(mock_run_script.call_args_list) == 4
+    assert mock_run_script.call_args_list[0] == mocker.call(
+        os.path.join(settings.NORTH_MIGRATIONS_ROOT, 'schemas',
+                     'extension.sql'))
+    assert mock_run_script.call_args_list[1] == mocker.call(
+        os.path.join(settings.NORTH_MIGRATIONS_ROOT, 'schemas',
+                     'roles.sql'))
+    assert mock_run_script.call_args_list[2] == mocker.call(
+        os.path.join(settings.NORTH_MIGRATIONS_ROOT, 'schemas',
+                     'schema_16.12.sql'))
+    assert mock_run_script.call_args_list[3] == mocker.call(
+        os.path.join(settings.NORTH_MIGRATIONS_ROOT, 'fixtures',
+                     'fixtures_16.12.sql'))
+    captured = capsys.readouterr()
+    assert captured.out == (
+        'Load extension.sql\n'
+        'Load roles.sql\n'
+        'Load schema\n'
+        '  Applying 16.12...\n'
+        'Load fixtures\n'
+        '  Applying 16.12...\n'
+    )
+
+
+def test_migrate_init_previous_fixture(capsys, settings, mocker):
+    root = os.path.dirname(__file__)
+    settings.NORTH_MIGRATIONS_ROOT = os.path.join(root, 'test_data/sql')
 
     # no fixtures for this version
     mocker.patch(
         'django_north.management.migrations.get_version_for_init',
         return_value='17.3')
-    del settings.NORTH_ADDITIONAL_SCHEMA_FILES
-    del settings.NORTH_AFTER_SCHEMA_FILES
+    mock_run_script = mocker.patch(
+        'django_north.management.commands.migrate.Command.run_script')
+    command = migrate.Command()
+    command.verbosity = 2
+
+    settings.NORTH_BEFORE_SCHEMA_FILES = []
+    settings.NORTH_AFTER_SCHEMA_FILES = []
+    settings.NORTH_ADDITIONAL_SCHEMA_FILES = []
     command.init_schema()
     assert len(mock_run_script.call_args_list) == 2
     assert mock_run_script.call_args_list[0] == mocker.call(
@@ -188,15 +277,23 @@ def test_migrate_init_schema(capsys, settings, mocker):
         '  Applying 16.12...\n'
     )
 
-    mock_run_script.reset_mock()
-    command = migrate.Command()
-    command.verbosity = 2
+
+def test_migrate_init_no_fixture(capsys, settings, mocker):
+    root = os.path.dirname(__file__)
+    settings.NORTH_MIGRATIONS_ROOT = os.path.join(root, 'test_data/sql')
 
     # no fixtures
     mocker.patch(
         'django_north.management.migrations.get_version_for_init',
         return_value='16.11')
-    del settings.NORTH_ADDITIONAL_SCHEMA_FILES
+    mock_run_script = mocker.patch(
+        'django_north.management.commands.migrate.Command.run_script')
+    command = migrate.Command()
+    command.verbosity = 2
+
+    settings.NORTH_BEFORE_SCHEMA_FILES = []
+    settings.NORTH_AFTER_SCHEMA_FILES = []
+    settings.NORTH_ADDITIONAL_SCHEMA_FILES = []
     command.init_schema()
     assert len(mock_run_script.call_args_list) == 1
     assert mock_run_script.call_args_list[0] == mocker.call(


### PR DESCRIPTION
In order to add grant files in the migration process when initialising the schema, we need to add them after the main schema. Otherwise the grants are not applied, since the table don't exists.

Since all `NORTH_ADDITIONAL_SCHEMA_FILES` are loaded before the schema, we need a new setting for such files.