### PR TITLE
Ignore more meta-commands

### DIFF
--- a/django_north/management/runner.py
+++ b/django_north/management/runner.py
@@ -22,6 +22,14 @@ def clean_sql_code(code):
             continue
         if stripped_line.startswith("--"):
             continue
+        if stripped_line == "\\gset":
+            continue
+        if stripped_line == "\\if":
+            continue
+        if stripped_line == "\\endif":
+            continue
+        if stripped_line == "\\gexec":
+            continue
         output += stripped_line + "\n"
     return output
 


### PR DESCRIPTION
I'm not sure this will be accepted because it can modify the behaviour.
However, in certain cases, in can be useful to have those meta-commands in the SQL file and handle them when running the files manually, and drop them if the files are run through django-north.