### PR TITLE
Missing parameters to septentrion lib call

### DIFF
--- a/django_north/management/commands/runserver.py
+++ b/django_north/management/commands/runserver.py
@@ -22,7 +22,9 @@ class Command(RunserverCommand):
             self.stdout.write(self.style.NOTICE("\n{}\n".format(e)))
             return
 
-        if not septentrion.is_schema_initialized():
+        if not septentrion.is_schema_initialized(
+            **septentrion_settings(connection)
+        ):
             self.stdout.write(self.style.NOTICE("\nSchema not inited.\n"))
             return
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "Django>=1.11",
         "sqlparse",
-        "septentrion[psycopg2]>=0.6.0",
+        "septentrion[psycopg2]>=0.6.1",
     ],
     tests_require=["tox"],
     license="MIT",

--- a/tests/test_runserver_command.py
+++ b/tests/test_runserver_command.py
@@ -17,7 +17,7 @@ def test_runserver_check_migrations(
     assert captured.out == '\nSomething...\n'
 
     # schema not inited
-    mocker.patch(
+    is_schema_initialized = mocker.patch(
         'septentrion.is_schema_initialized', return_value=False)
     command = runserver.Command()
     mock_plan.side_effect = None
@@ -25,6 +25,8 @@ def test_runserver_check_migrations(
     command.check_migrations()
     captured = capsys.readouterr()
     assert captured.out == '\nSchema not inited.\n'
+    _, kwargs = is_schema_initialized.call_args
+    assert "table" in kwargs
 
     # schema inited, missing migrations
     command = runserver.Command()


### PR DESCRIPTION
The function was called with septentrion's default params.

Not sure exactly what to test, because I think the exact parameters can change in north depending on whether we're in local, CI or what.